### PR TITLE
fix: Remove unnecessary JavaScript Tag

### DIFF
--- a/views/admin/tpl/oscpaypalconfig.tpl
+++ b/views/admin/tpl/oscpaypalconfig.tpl
@@ -393,4 +393,6 @@
 </div>
 [{include file="bottomitem.tpl"}]
 
+[{*
 <script id="paypal-js" src="https://www.sandbox.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js"></script>
+*}]


### PR DESCRIPTION
The data-paypal-* attributes not set anymore and an error in console log occurs with the message "No Paypal Launch Url Found"