### PR TITLE
fix modulesettings instantiation missing a parameter

### DIFF
--- a/src/Core/Events/Events.php
+++ b/src/Core/Events/Events.php
@@ -163,11 +163,13 @@ class Events
         $context = $container->get(ContextInterface::class);
         /** @var ModuleConfigurationDaoBridgeInterface $moduleConfigurationDaoBridgeInterface */
         $moduleConfigurationDaoBridgeInterface = $container->get(ModuleConfigurationDaoBridgeInterface::class);
+        $logger = $container->get('OxidSolutionCatalysts\PayPal\Logger');
 
         return new ModuleSettings(
             $moduleSettingsBridge,
             $context,
-            $moduleConfigurationDaoBridgeInterface
+            $moduleConfigurationDaoBridgeInterface,
+            $logger
         );
     }
 }


### PR DESCRIPTION
With the latest changes in the ModuleSettings, the new argument for the constructor is missing.