### PR TITLE
delete the order

### DIFF
--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -201,8 +201,11 @@ class Order extends Order_parent
         if (is_null($transactionId)) {
             $capture = $this->getOrderPaymentCapture($payPalOrderId);
             if (!$payPalPaymentSuccess || is_null($capture) || $capture->status === 'DECLINED') {
-                $paymentService = $this->getServiceFromContainer(PaymentService::class);
-                $paymentService->removeTemporaryOrder();
+                // We don't have a capture but the order has already been created with the order number.
+                // So it is no longer a temporary order with could be deleted via
+                // $this->getServiceFromContainer(PaymentService::class)->removeTemporaryOrder();
+                // That's why the order is deleted via delete(). Now there is a gap in the order numbers
+                $this->delete();
                 throw PayPalException::cannotFinalizeOrderAfterExternalPayment($payPalOrderId, $paymentsId);
             }
             $this->setTransId($capture->id);


### PR DESCRIPTION
We don't have a capture but the order has already been created with the order number. So it is no longer a temporary order with could be deleted via $this->getServiceFromContainer(PaymentService::class)->removeTemporaryOrder(); That's why the order is deleted via delete(). Now there is a gap in the order numbers