### PR TITLE
Fix admin block parent call

### DIFF
--- a/views/blocks/admin/admin_order_main_send_order.tpl
+++ b/views/blocks/admin/admin_order_main_send_order.tpl
@@ -1,3 +1,3 @@
 [{if !$oView->paidWithPayPal()}]
-    [{$marty.block.parent}]
+    [{$smarty.block.parent}]
 [{/if}]


### PR DESCRIPTION
The parent block is not shown because there is a missing letter ($marty instead of $smarty)