### PR TITLE
More user-friendly when returning

### DIFF
--- a/views/blocks/page/checkout/select_payment.tpl
+++ b/views/blocks/page/checkout/select_payment.tpl
@@ -2,6 +2,14 @@
     [{include file='modules/osc/paypal/select_payment.tpl'}]
 [{elseif $sPaymentID == "oscpaypal_sepa" || $sPaymentID == "oscpaypal_cc_alternative"}]
     [{assign var="config" value=$oViewConf->getPayPalCheckoutConfig()}]
+
+    [{* Reset PayPal Checkout Session and redirect to Payments Selection Page, when PayPal Express Session active and not closed *}]
+    [{if $sPaymentID == 'oscpaypal_cc_alternative' && $config->isActive() && $oViewConf->isPayPalExpressSessionActive()}]
+        <script>
+            window.location.replace('[{$oViewConf->getCancelPayPalPaymentUrl()}]');
+        </script>
+    [{/if}]
+
     [{if $config->isActive() && !$oViewConf->isPayPalExpressSessionActive()}]
         [{include file="modules/osc/paypal/sepa_cc_alternative.tpl" sPaymentID=$sPaymentID}]
     [{/if}]


### PR DESCRIPTION
If you click on the "Debit or credit card" button for the "PayPal credit card fallback" payment method, you have no option to end the session and when you return to the payment page, the "PayPal credit card fallback" and "SEPA direct debit" payment methods are no longer displayed.