### PR TITLE
add PayPal express button design example

### DIFF
--- a/views/tpl/shared/paymentbuttons.tpl
+++ b/views/tpl/shared/paymentbuttons.tpl
@@ -59,6 +59,12 @@
             });
         [{else}]
             button = paypal.Buttons({
+                style: {
+                    shape: "rect",
+                    layout: "vertical",
+                    color: "gold",
+                    label: "pay",
+                },
                 [{if $oViewConf->getCountryRestrictionForPayPalExpress()}]
                 onShippingChange: function (data, actions) {
                     if (!countryRestriction.includes(data.shipping_address.country_code)) {


### PR DESCRIPTION
@mariolorenz I added an example code to change the PayPal Express button design. To get back to the old look.

I based myself on the old PayPal Express Button Design and the PayPal Studio https://developer.paypal.com/studio/checkout/standard/integrate

Old PayPal Express Button Design

![old-paypal-express-button](https://github.com/user-attachments/assets/bc2a66af-1b87-4403-a840-ac0ce01a4d86)

New PayPal Express Button Design Example

![new-paypal-express-button-design-example](https://github.com/user-attachments/assets/b1d48c4e-73f0-4983-9378-22971c43d582)

Would it be possible to store the design options in the module settings for the shop owner?

The shop owner's thoughts in the original wording:

> Bei dem Button so wie er im Standard angezeigt wird vermute ich das viele Kunden denken werden dass es sich um eine Werbung handelt bzw. einen Hinweis das man grundsätzlich mit PayPal zahlen kann, die Beschriftung "direkt zu PayPal" ist für  mich das einzige was Sinn macht um dem Kunden zu sagen dass er den normalen Bestellvorgang damit überspringen kann.


