### PR TITLE
also Handling for temp-order with OrderNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.1] - 2024-??-??
+
+### FIX
+
+- Temporary orders that are no longer needed and already have an order number will be cancelled. Temporary orders without an order number will still be deleted
+
 ## [2.5.0] - 2024-08-16
 
 ### FIX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### FIX
 
-- Temporary orders that are no longer needed and already have an order number will be cancelled. Temporary orders without an order number will still be deleted
+- [0007711](https://bugs.oxid-esales.com/view.php?id=7711): Temporary orders that are no longer needed and already have an order number will be cancelled. Temporary orders without an order number will still be deleted
 
 ## [2.5.0] - 2024-08-16
 

--- a/metadata.php
+++ b/metadata.php
@@ -61,7 +61,7 @@ $aModule = [
         'en' => 'Use of the online payment service from PayPal. Documentation: <a href="https://docs.oxid-esales.com/modules/paypal-checkout/en/latest/" target="_blank">PayPal Checkout</a>'
     ],
     'thumbnail' => 'out/img/paypal.png',
-    'version' => '2.5.0',
+    'version' => '2.5.1-rc.1',
     'author' => 'OXID eSales AG',
     'url' => 'https://www.oxid-esales.com',
     'email' => 'info@oxid-esales.com',

--- a/src/Service/Payment.php
+++ b/src/Service/Payment.php
@@ -490,14 +490,20 @@ class Payment
         $orderModel->load($sessionOrderId);
 
         if (
-            $orderModel->isLoaded() &&
-            !$orderModel->hasOrderNumber()
+            $orderModel->isLoaded()
         ) {
-            $orderModel->delete();
+            $orderModel->cancelOrder();
             $this->logger->log('debug', sprintf(
-                'Temporary order without Order number and with id %s was deleted',
+                'Temporary order with id %s was canceled',
                 $sessionOrderId
             ));
+            if (!$orderModel->hasOrderNumber()) {
+                $orderModel->delete();
+                $this->logger->log('debug', sprintf(
+                    'Temporary order without Order number and with id %s was deleted',
+                    $sessionOrderId
+                ));
+            }
         }
 
         PayPalSession::unsetPayPalOrderId();


### PR DESCRIPTION
Temporary orders that are no longer needed and already have an order number will be cancelled. Temporary orders without an order number will still be deleted