### PR TITLE
Fix GooglePay not working on the first go

### DIFF
--- a/views/tpl/shared/googlepay.tpl
+++ b/views/tpl/shared/googlepay.tpl
@@ -214,12 +214,12 @@
                         console.log(orderResponse);
                         [{/if}]
                         await onApprove(orderResponse);
-                        await onCreated(orderResponse);
+                        onCreated(orderResponse);
                     }
                     function onCreated(confirmOrderResponse, actions) {
                         captureData = new FormData();
                         captureData.append('orderID', confirmOrderResponse.id);
-                        return fetch('[{$sSelfLink|cat:"cl=order&fnc=captureGooglePayOrder&context=continue&aid="|cat:$aid|cat:"&stoken="|cat:$sToken|cat:"&sDeliveryAddressMD5="|cat:$oView->getDeliveryAddressMD5()}]', {
+                        fetch('[{$sSelfLink|cat:"cl=order&fnc=captureGooglePayOrder&context=continue&aid="|cat:$aid|cat:"&stoken="|cat:$sToken|cat:"&sDeliveryAddressMD5="|cat:$oView->getDeliveryAddressMD5()}]', {
                             method: 'post',
                             body: captureData
                         }).then(function (res) {
@@ -242,12 +242,11 @@
                         });
                     }
 
-                    function onApprove(confirmOrderResponse, actions) {
-
+                    async function onApprove(confirmOrderResponse, actions) {
                         const url = '[{$sSelfLink|cat:"cl=order&fnc=createGooglePayOrder&context=continue&aid="|cat:$aid|cat:"&stoken="|cat:$sToken|cat:"&sDeliveryAddressMD5="|cat:$oView->getDeliveryAddressMD5()}]';
                         createData = new FormData();
                         createData.append('orderID', confirmOrderResponse.id);
-                        fetch(url, {
+                        return await fetch(url, {
                             method: 'POST',
                             body: createData
                         }).then(function (res) {

--- a/views/tpl/shared/googlepay.tpl
+++ b/views/tpl/shared/googlepay.tpl
@@ -274,7 +274,7 @@
         }
     }
 
-    [{if false}]</style>[{/if}]
+    [{if false}]</script>[{/if}]
 [{/capture}]
 [{oxscript include="https://pay.google.com/gp/p/js/pay.js"}]
 [{oxscript add=$smarty.capture.detailsGooglePayScript}]


### PR DESCRIPTION
Problem:
If you want to do a payment by google pay you will get a message first that you maybe should retry or pick another payment method, even if everything is correct. This is annoying and could lead to some customers leaving the shop after the first try doesn't succeed. Most of the time it'll work if you click the google pay button the second time like the error message suggests.

After hours of spending understanding the code it was actually quite simple.

- fixed problem with GooglePay order don't get accepted on the first try, because of paypal order which is captured is not the one which is approved, don't create another paypal order, just go with the one already created to avoid the problem

- really wait for onApprove to be finished

Hope this helps