### PR TITLE
Remove Escaping of sCountryRestriction in order to avoid js errors

### DIFF
--- a/views/twig/extensions/themes/default/layout/base.html.twig
+++ b/views/twig/extensions/themes/default/layout/base.html.twig
@@ -17,7 +17,7 @@
         {% set sCountryRestriction = oViewConf.getCountryRestrictionForPayPalExpress() %}
         {% if sCountryRestriction %}
             <script>
-                const countryRestriction = [{{ sCountryRestriction }}];
+                const countryRestriction = [{{ sCountryRestriction|raw }}];
             </script>
         {% endif %}
         {% if submitCart %}


### PR DESCRIPTION
Output of countryRestriction Array in twig Template leads to js error as the single quote has been escaped to "&#39;".