### PR TITLE
Price decimal precision set to 2 in PayPal related orders

### DIFF
--- a/metadata.php
+++ b/metadata.php
@@ -12,6 +12,7 @@ use OxidEsales\Eshop\Application\Controller\PaymentController;
 use OxidEsales\Eshop\Application\Controller\Admin\OrderMain;
 use OxidEsales\Eshop\Application\Controller\Admin\OrderOverview;
 use OxidEsales\Eshop\Application\Model\Article;
+use OxidEsales\Eshop\Application\Model\OrderArticle;
 use OxidEsales\Eshop\Application\Model\Basket;
 use OxidEsales\Eshop\Application\Model\Order;
 use OxidEsales\Eshop\Application\Model\State;
@@ -38,6 +39,7 @@ use OxidSolutionCatalysts\PayPal\Core\InputValidator as PayPalInputValidator;
 use OxidSolutionCatalysts\PayPal\Core\ShopControl as PayPalShopControl;
 use OxidSolutionCatalysts\PayPal\Core\ViewConfig as PayPalViewConfig;
 use OxidSolutionCatalysts\PayPal\Model\Article as PayPalArticle;
+use OxidSolutionCatalysts\PayPal\Model\OrderArticle  as PayPalOrderArticle;
 use OxidSolutionCatalysts\PayPal\Model\Basket as PayPalBasket;
 use OxidSolutionCatalysts\PayPal\Model\Order as PayPalOrder;
 use OxidSolutionCatalysts\PayPal\Model\State as PayPalState;
@@ -73,6 +75,7 @@ $aModule = [
         User::class => PayPalUser::class,
         Basket::class => PayPalBasket::class,
         Article::class => PayPalArticle::class,
+        OrderArticle::class => PayPalOrderArticle::class,
         Payment::class => PayPalPayment::class,
         PaymentGateway::class => PayPalPaymentGateway::class,
         OrderController::class => PayPalFrontEndOrderController::class,

--- a/src/Controller/Admin/PayPalOrderController.php
+++ b/src/Controller/Admin/PayPalOrderController.php
@@ -187,14 +187,14 @@ class PayPalOrderController extends AdminDetailsController
     public function refund(): void
     {
         $request = Registry::getRequest();
-        $refundAmount = $request->getRequestEscapedParameter('refundAmount');
-        $refundAmount = str_replace(",", ".", $refundAmount);
-        $refundAmount = preg_replace("/[\,\.](\d{3})/", "$1", $refundAmount);
+        $order = $this->getOrder();
+        $currency = Registry::getConfig()->getCurrencyObject($order->oxorder__oxcurrency->value);
+        $currency->decimal = 2; //PayPal requires decimal precision of 2
+        $refundAmount = str_replace(",", ".", $request->getRequestEscapedParameter('refundAmount'));
+        $refundAmount = number_format($refundAmount, $currency->decimal, $currency->dec, $currency->thousand);
         $invoiceId = $request->getRequestEscapedParameter('invoiceId');
         $refundAll = $request->getRequestEscapedParameter('refundAll');
         $noteToPayer = $request->getRequestEscapedParameter('noteToPayer');
-
-        $order = $this->getOrder();
 
         $capture = $order->getOrderPaymentCapture();
         if ($capture instanceof Capture) {
@@ -366,7 +366,10 @@ class PayPalOrderController extends AdminDetailsController
      */
     public function formatPrice($price)
     {
-        return Registry::getLang()->formatCurrency($price);
+        $currency = Registry::getConfig()->getActShopCurrencyObject();
+        $currency->decimal= 2;
+
+        return Registry::getLang()->formatCurrency($price, $currency);
     }
 
     /**

--- a/src/Core/OrderRequestFactory.php
+++ b/src/Core/OrderRequestFactory.php
@@ -307,6 +307,8 @@ class OrderRequestFactory
         $basket = $this->basket;
         $itemCategory = $this->getItemCategoryByBasketContent();
         $currency = $basket->getBasketCurrency();
+        //only two decimal place precision is supported in PayPal
+        $currency->decimal = 2;
         $language = Registry::getLang();
         $items = [];
 
@@ -323,8 +325,13 @@ class OrderRequestFactory
 
             // no zero price articles in the list
             if ($itemUnitPrice && $itemUnitPrice->getBruttoPrice() > 0) {
+                $bruttoPrice = number_format($itemUnitPrice->getBruttoPrice(),
+                    $currency->decimal,
+                    $currency->dec,
+                    $currency->thousand
+                );
                 $item->unit_amount = PriceToMoney::convert(
-                    $itemUnitPrice->getBruttoPrice(),
+                    $bruttoPrice,
                     $currency
                 );
                 // tax - we use 0% and calculate with brutto to avoid rounding errors

--- a/src/Core/PayPalRequestAmountFactory.php
+++ b/src/Core/PayPalRequestAmountFactory.php
@@ -24,6 +24,8 @@ class PayPalRequestAmountFactory
     {
         $netMode = $basket->isCalculationModeNetto();
         $currency = $basket->getBasketCurrency();
+        //only two decimal place precision is supported in PayPal
+        $currency->decimal = 2;
 
         //Discount
         $discount = $basket->getPayPalCheckoutDiscount();
@@ -56,7 +58,7 @@ class PayPalRequestAmountFactory
 
         //Total amount
         $amount = new AmountWithBreakdown();
-        $amount->value = $brutBasketTotal;
+        $amount->value = number_format($brutBasketTotal, $currency->decimal, $currency->dec, $currency->thousand);
         $amount->currency_code = $total->currency_code;
 
         //Cost breakdown

--- a/src/Model/OrderArticle.php
+++ b/src/Model/OrderArticle.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidSolutionCatalysts\PayPal\Model;
+
+use OxidEsales\EshopCommunity\Core\Registry;
+use OxidSolutionCatalysts\PayPal\Core\PayPalDefinitions;
+
+class OrderArticle extends OrderArticle_parent
+{
+
+    /**
+     * Currency in PayPal orders needs to have decimal precision set to 2
+     *
+     * @param $order
+     * @return \stdClass|null
+     */
+    public function getCurrency($order): ?\stdClass
+    {
+        $currency = Registry::getConfig()->getCurrencyObject($order->oxorder__oxcurrency->value);
+        $currency->decimal = 2;
+
+        return $currency;
+    }
+
+    public function getTotalBrutPriceFormated()
+    {
+        $order = $this->getOrder();
+        $currency = $this->getCurrency($order);
+        $isPayPalPayment = PayPalDefinitions::isPayPalPayment($order->oxorder__oxpaymenttype->value);
+
+        return $isPayPalPayment ?
+            number_format(parent::getTotalBrutPriceFormated(), $currency->decimal, $currency->dec, $currency->thousand)
+            : parent::getTotalBrutPriceFormated();
+    }
+
+    public function getBrutPriceFormated()
+    {
+        $order = $this->getOrder();
+        $currency = $this->getCurrency($order);
+        $isPayPalPayment = PayPalDefinitions::isPayPalPayment($order->oxorder__oxpaymenttype->value);
+
+        return $isPayPalPayment ?
+            number_format(parent::getBrutPriceFormated(), $currency->decimal, $currency->dec, $currency->thousand)
+            : parent::getTotalBrutPriceFormated();
+    }
+
+    public function getNetPriceFormated()
+    {
+        $order = $this->getOrder();
+        $currency = $this->getCurrency($order);
+        $isPayPalPayment = PayPalDefinitions::isPayPalPayment($order->oxorder__oxpaymenttype->value);
+
+        return $isPayPalPayment ?
+            number_format(parent::getNetPriceFormated(), $currency->decimal, $currency->dec, $currency->thousand)
+            : parent::getTotalBrutPriceFormated();
+    }
+
+    public function getTotalNetPriceFormated()
+    {
+        $order = $this->getOrder();
+        $currency = $this->getCurrency($order);
+        $isPayPalPayment = PayPalDefinitions::isPayPalPayment($order->oxorder__oxpaymenttype->value);
+
+        return $isPayPalPayment ?
+            number_format(parent::getTotalNetPriceFormated(), $currency->decimal, $currency->dec, $currency->thousand)
+            : parent::getTotalBrutPriceFormated();
+    }
+
+}


### PR DESCRIPTION
Preventing prices amounts values to be at precision 2 in PayPal orders context.