### PR TITLE
PSPAYPAL-915 Credit card validation

### DIFF
--- a/views/smarty/frontend/blocks/page/checkout/checkout_order_btn_submit_bottom.tpl
+++ b/views/smarty/frontend/blocks/page/checkout/checkout_order_btn_submit_bottom.tpl
@@ -8,7 +8,7 @@
     submitButton.addEventListener('click', function() {
     event.preventDefault();
     this.disabled = true;
-    orderConfirmAgbBottom.submit();
+    orderConfirmAgbBottom.dispatchEvent(new CustomEvent('submit', {cancelable: true}));
     });
     [{/capture}]
     [{oxscript add=$smarty.capture.oscpaypal_madClickPrevention}]

--- a/views/smarty/frontend/blocks/page/checkout/checkout_order_btn_submit_bottom.tpl
+++ b/views/smarty/frontend/blocks/page/checkout/checkout_order_btn_submit_bottom.tpl
@@ -2,14 +2,21 @@
 [{if "oscpaypal" == $payment->getId()}]
     <input type="hidden" name="vaultPayment" id="oscPayPalVaultPayment" value="">
     [{capture name="oscpaypal_madClickPrevention"}]
-    const submitButton = document.querySelector('#orderConfirmAgbBottom .submitButton');
-    const orderConfirmAgbBottom = document.getElementById('orderConfirmAgbBottom');
+        const submitButton = document.querySelector('#orderConfirmAgbBottom .submitButton');
+        const orderConfirmAgbBottom = document.getElementById('orderConfirmAgbBottom');
 
-    submitButton.addEventListener('click', function() {
-    event.preventDefault();
-    this.disabled = true;
-    orderConfirmAgbBottom.dispatchEvent(new CustomEvent('submit', {cancelable: true}));
-    });
+        submitButton.addEventListener('click', function(event) {
+            event.preventDefault();
+
+            // Create CustomEvent and check if it was canceled
+            const submitEvent = new CustomEvent('submit', {cancelable: true});
+            const eventNotCancelled = orderConfirmAgbBottom.dispatchEvent(submitEvent);
+
+            // Only deactivate the button if the validation was successful (event not canceled)
+            if (eventNotCancelled) {
+                this.disabled = true;
+            }
+        });
     [{/capture}]
     [{oxscript add=$smarty.capture.oscpaypal_madClickPrevention}]
 [{/if}]

--- a/views/twig/extensions/themes/default/page/checkout/order.html.twig
+++ b/views/twig/extensions/themes/default/page/checkout/order.html.twig
@@ -79,10 +79,18 @@
             const orderConfirmAgbBottom = document.getElementById('orderConfirmAgbBottom');
 
             submitButton.addEventListener('click', function(event) {
-            event.preventDefault();
-            this.disabled = true;
-            orderConfirmAgbBottom.dispatchEvent(new CustomEvent('submit', {cancelable: true}));
+                event.preventDefault();
+
+                // Create CustomEvent and check if it was canceled
+                const submitEvent = new CustomEvent('submit', {cancelable: true});
+                const eventNotCancelled = orderConfirmAgbBottom.dispatchEvent(submitEvent);
+
+                // Only deactivate the button if the validation was successful (event not canceled)
+                if (eventNotCancelled) {
+                    this.disabled = true;
+                }
             });
+
         {% endcapture %}
         {{ script({ add: oscpaypal_madClickPrevention, dynamic: __oxid_include_dynamic }) }}
 

--- a/views/twig/extensions/themes/default/page/checkout/order.html.twig
+++ b/views/twig/extensions/themes/default/page/checkout/order.html.twig
@@ -81,7 +81,7 @@
             submitButton.addEventListener('click', function(event) {
             event.preventDefault();
             this.disabled = true;
-            orderConfirmAgbBottom.submit();
+            orderConfirmAgbBottom.dispatchEvent(new CustomEvent('submit', {cancelable: true}));
             });
         {% endcapture %}
         {{ script({ add: oscpaypal_madClickPrevention, dynamic: __oxid_include_dynamic }) }}


### PR DESCRIPTION
Call `dispatchEvent(new CustomEvent('submit', {cancelable: true}));` instead of `sudmit` method in order to trigger submit event and hence form validation.