### PR TITLE
prevent PayPal-specific sendorder logic from running on non-PayPal or…

### DIFF
--- a/src/Controller/Admin/OrderOverview.php
+++ b/src/Controller/Admin/OrderOverview.php
@@ -7,6 +7,7 @@
 
 namespace OxidSolutionCatalysts\PayPal\Controller\Admin;
 
+use OxidSolutionCatalysts\PayPal\Core\PayPalDefinitions;
 use OxidSolutionCatalysts\PayPal\Traits\AdminOrderTrait;
 
 /**
@@ -24,8 +25,11 @@ class OrderOverview extends OrderOverview_parent
     public function sendorder()
     {
         parent::sendorder();
-        if ($this->isPayPalStandardOnDeliveryCapture()) {
-            $this->capturePayPalStandard();
+
+        $paymentId = $this->getOrder()->getPayment()->getId();
+
+        if (PayPalDefinitions::isPayPalPayment($paymentId) && $this->isPayPalOrderCaptureOnDelivery()) {
+            $this->capturePayPalOrder();
         }
     }
 }


### PR DESCRIPTION
Hey @mariolorenz , one notice beforehand: This appears to affect all Versions from b-7.x and b-6.x

### prevent PayPal-specific sendorder logic from running on non-PayPal orders

The sendorder method now checks if the payment is a PayPal payment
before attempting capture, avoiding errors on other payment types.

### Bug description

When using the "Send now / jetzt versenden" button in the Admin Order Overview **on an Order which was not payed with PayPal**, an error will be thrown:

```
OXID Logger.ERROR: Syntax error ["[object] (JsonException(code: 4): Syntax error at /var/www/vendor/oxid-solution-catalysts/paypal-client/src/Exception/ApiException.php:44)
[stacktrace]
#0 /var/www/vendor/oxid-solution-catalysts/paypal-client/src/Exception/ApiException.php(44): json_decode('', true, 512, 4194304)
#1 /var/www/vendor/oxid-solution-catalysts/paypal-client/src/Service/BaseService.php(59): OxidSolutionCatalysts\\PayPalApi\\Exception\\ApiException->__construct(Object(GuzzleHttp\\Exception\\ClientException))
#2 /var/www/vendor/oxid-solution-catalysts/paypal-client/src/Service/BaseService.php(114): OxidSolutionCatalysts\\PayPalApi\\Service\\BaseService->send('GET', '/orders/', Array, Array, NULL)
#3 /var/www/vendor/oxid-solution-catalysts/paypal-client/generated/Service/Orders.php(81): OxidSolutionCatalysts\\PayPalApi\\Service\\BaseService->sendWithRequestResponseLogging('GET', '/orders/', Array, Array, NULL)
#4 /var/www/vendor/oxid-solution-catalysts/paypal-module/src/Model/Order.php(379): OxidSolutionCatalysts\\PayPalApi\\Service\\Orders->showOrderDetails('', '', 'OXID_Cart_PPCP_...')
#5 /var/www/vendor/oxid-solution-catalysts/paypal-module/src/Traits/AdminOrderTrait.php(158): OxidSolutionCatalysts\\PayPal\\Model\\Order->getPayPalCheckoutOrder()
#6 /var/www/vendor/oxid-solution-catalysts/paypal-module/src/Traits/AdminOrderTrait.php(93): OxidSolutionCatalysts\\PayPal\\Controller\\Admin\\OrderOverview->getPayPalCheckoutOrder()
#7 /var/www/vendor/oxid-solution-catalysts/paypal-module/src/Traits/AdminOrderTrait.php(107): OxidSolutionCatalysts\\PayPal\\Controller\\Admin\\OrderOverview->isAuthorizedPayPalOrder()
#8 /var/www/vendor/oxid-solution-catalysts/paypal-module/src/Controller/Admin/OrderOverview.php(27): OxidSolutionCatalysts\\PayPal\\Controller\\Admin\\OrderOverview->isPayPalOrderCaptureOnDelivery()
#9 /var/www/source/Core/Controller/BaseController.php(512): OxidSolutionCatalysts\\PayPal\\Controller\\Admin\\OrderOverview->sendorder()
#10 /var/www/source/Core/ShopControl.php(305): OxidEsales\\EshopCommunity\\Core\\Controller\\BaseController->executeFunction('sendorder')
#11 /var/www/source/Core/ShopControl.php(239): OxidEsales\\EshopCommunity\\Core\\ShopControl->executeAction(Object(OxidSolutionCatalysts\\PayPal\\Controller\\Admin\\OrderOverview), 'sendorder')
#12 /var/www/source/Core/ShopControl.php(124): OxidEsales\\EshopCommunity\\Core\\ShopControl->process('OxidEsales\\\\Esho...', 'sendorder', NULL, NULL)
#13 /var/www/source/Core/Oxid.php(27): OxidEsales\\EshopCommunity\\Core\\ShopControl->start()
#14 /var/www/source/index.php(16): OxidEsales\\EshopCommunity\\Core\\Oxid::run()
#15 /var/www/source/admin/index.php(12): require_once('/var/www/source...')
#16 {main}
"] []
```

### The problem

The Method AdminOrderTrait::isPayPalOrderCaptureOnDelivery() never checks if the order is actually PayPal Order and executes isAuthorizedPayPalOrder() which results in calling the paypal API on a non PayPal Order.