### PR TITLE
fix floating point error when performing a manual refund

### DIFF
--- a/src/Controller/Admin/PayPalOrderController.php
+++ b/src/Controller/Admin/PayPalOrderController.php
@@ -209,7 +209,7 @@ class PayPalOrderController extends AdminDetailsController
             if (!$refundAll) {
                 $request->initAmount();
                 $request->amount->currency_code = $capture->amount->currency_code;
-                $request->amount->value = $refundAmount;
+                $request->amount->value = number_format($refundAmount, 2, '.', null);
             }
 
             /** @var Payments $paymentService */


### PR DESCRIPTION
When refunding an amount that can cause a floating point error (e.g. 3.99), the refund call used an amount like 3.9900000000000002131628207280300557613372802734375