### PR TITLE
Fix: If Apple Pay is selected with a different language and currency,…

### DIFF
--- a/views/twig/frontend/applepay_button.html.twig
+++ b/views/twig/frontend/applepay_button.html.twig
@@ -336,7 +336,7 @@
                 }).then(function (data) {
                     console.log('Order creation capture data:', data);
                     var goNext = Array.isArray(data.location) && data.location[0];
-                    window.location.href = '{{ sSelfLink }}' + goNext;
+                    window.location.href = '{{ sSelfLink|raw }}' + goNext;
 
                     if (data.status === "ERROR") {
                         location.reload();


### PR DESCRIPTION
… then reach the thank you page

If a customer selects a different language and currency, the GET parameters ensure that when using Apple Pay as the payment method, the customer does not reach the thank you page but instead receives an error message.