### PR TITLE
[0007887]: Fix paypal express ignoring session shipping id

### DIFF
--- a/src/Traits/PayPalBasketTrait.php
+++ b/src/Traits/PayPalBasketTrait.php
@@ -77,8 +77,14 @@ trait PayPalBasketTrait
     private function getActiveShippingSetId($session, $user, $basket): void
     {
         $shippingSetId = $session->getVariable('sShipSet');
+        $basketShippingId = $basket ? $basket->getShippingId() : '';
+
+        if ($shippingSetId && $shippingSetId === $basketShippingId) {
+            return;
+        }
 
         if ($shippingSetId) {
+            $basket->setShipping($shippingSetId);
             return;
         }
 


### PR DESCRIPTION
Checks if basket shipping id is same as session shipping id and updates the basket shipping id if it is not the case