### PR TITLE
Fix API error 'AMOUNT_MISMATCH' if blShowVATForPayCharge is checked in the shop settings

### DIFF
--- a/src/Service/PayPalAmountValidator.php
+++ b/src/Service/PayPalAmountValidator.php
@@ -24,34 +24,12 @@ class PayPalAmountValidator
      */
     public function validateAndAdjustOrder(array $orderData): array
     {
-        // Enrich breakdown using services if Basket is present
-        try {
-            // Fetch basket directly from session; do not rely on orderData['basket']
-            $session = \OxidEsales\Eshop\Core\Registry::getSession();
-            $basket = $session ? $session->getBasket() : null;
-            if ($basket instanceof \OxidEsales\Eshop\Application\Model\Basket) {
-                /** @var \OxidSolutionCatalysts\PayPal\Service\VatOptionsService $vatSvc */
-                $vatSvc = \OxidEsales\Eshop\Core\Registry::get(VatOptionsService::class);
-                if ($vatSvc->isPaymentVatVisible()) {
-                    $paymentVat = $vatSvc->getPaymentVatAmount($basket);
-                    if ($paymentVat > 0) {
-                        $orderData['breakdown']['payment_vat'] = $paymentVat;
-                    }
-                }
-            }
-        } catch (\Throwable $e) {
-            // Do not block checkout on service retrieval issues
-        }
-
         // Calculate items total (including subtracting discounts if provided in breakdown)
         $items = $orderData['items'] ?? [];
         $itemsTotal = $this->calculateItemsTotal($items, $orderData['breakdown'] ?? []);
 
         // If no items are present, we are not in NET items mode; do not adjust amounts
         if (empty($items)) {
-            if (isset($orderData['breakdown']['payment_vat'])) {
-                unset($orderData['breakdown']['payment_vat']);
-            }
             return $orderData;
         }
 
@@ -117,10 +95,6 @@ class PayPalAmountValidator
             ];
         }
 
-        if (isset($orderData['breakdown']['payment_vat'])) {
-            unset($orderData['breakdown']['payment_vat']);
-        }
-
         return $orderData;
     }
 
@@ -145,11 +119,6 @@ class PayPalAmountValidator
         $shippingDiscount = isset($breakdown['shipping_discount']['value'])
             ? (float)$breakdown['shipping_discount']['value'] : 0.0;
         $total -= ($discount + $shippingDiscount);
-
-        $paymentVat = isset($breakdown['payment_vat']) ? (float)$breakdown['payment_vat'] : 0.0;
-        if ($paymentVat > 0) {
-            $total -= $paymentVat;
-        }
 
         return $total;
     }

--- a/tests/Unit/Core/PayPalAmountValidatorTest.php
+++ b/tests/Unit/Core/PayPalAmountValidatorTest.php
@@ -131,4 +131,61 @@ class PayPalAmountValidatorTest extends TestCase
         // No shipping_discount expected in this branch
         $this->assertArrayNotHasKey('shipping_discount', $adjusted['breakdown']);
     }
+
+    /**
+     * Regression test for AMOUNT_MISMATCH when a payment-method surcharge is used
+     * together with "show VAT for payment surcharge" (blShowVATForPayCharge).
+     *
+     * The surcharge is already contained gross in amount_value, so its VAT part must
+     * NOT be subtracted from the items total. Otherwise the compensating adjustment item
+     * becomes too large by the surcharge VAT and the breakdown no longer matches amount.
+     *
+     * Real-world case (gross mode):
+     *   item 386.78 + shipping 6.95 + surcharge 0.39 (= 0.33 net) = 394.12 = amount_value
+     *   surcharge VAT part = 0.06
+     * Buggy behaviour produced an adjustment of 0.45 (=0.39+0.06) and item_total 387.23,
+     * so PayPal computed 387.23 + 6.95 = 394.18 != 394.12 -> AMOUNT_MISMATCH.
+     */
+    public function testPaymentVatInBreakdownDoesNotDistortAdjustment(): void
+    {
+        $validator = new PayPalAmountValidator();
+
+        $orderData = [
+            'items' => [
+                [
+                    'quantity' => 1,
+                    'unit_amount' => ['currency_code' => 'EUR', 'value' => '386.78'],
+                    'tax' => ['currency_code' => 'EUR', 'value' => '0.00'],
+                ],
+            ],
+            'breakdown' => [
+                'item_total' => ['currency_code' => 'EUR', 'value' => '386.78'],
+                'tax_total' => ['currency_code' => 'EUR', 'value' => '0.00'],
+                'shipping' => ['currency_code' => 'EUR', 'value' => '6.95'],
+                'discount' => ['currency_code' => 'EUR', 'value' => '0.00'],
+                // Simulates the previously injected (and faulty) payment VAT value.
+                // It must be ignored by the validator now.
+                'payment_vat' => 0.06,
+            ],
+            'amount_value' => 394.12,
+        ];
+
+        $adjusted = $validator->validateAndAdjustOrder($orderData);
+
+        // Adjustment item must cover the full gross surcharge (0.39), not 0.45.
+        $this->assertCount(2, $adjusted['items']);
+        $adjustmentItem = end($adjusted['items']);
+        $this->assertSame('0.39', $adjustmentItem['unit_amount']['value']);
+
+        // item_total must be 386.78 + 0.39 = 387.17.
+        $this->assertSame('387.17', $adjusted['breakdown']['item_total']['value']);
+
+        // Decisive assertion: breakdown total must equal amount_value.
+        $bd = $adjusted['breakdown'];
+        $breakdownTotal = (float)$bd['item_total']['value']
+            + (float)$bd['shipping']['value']
+            + (float)$bd['tax_total']['value']
+            - (float)$bd['discount']['value'];
+        $this->assertEqualsWithDelta(394.12, $breakdownTotal, 0.001);
+    }
 }


### PR DESCRIPTION
It's still not possible to submit bugs to the official bugtracker, so here is a direct bugfix with error description.

German TL;DR: Wenn man die Option "_Die in den Zahlungsarten-Gebühren enthaltene Mehrwertsteuer im Warenkorb und in der Rechnung anzeigen_" aktiviert und die Zahlungsart Paypal (oscpaypal) kostenpflichtig ist (z.B. 39 Cent), dann wird der MwSt-Satz der Zahlungskosten vom Gesamtbetrag subtrahiert, was zu einem Fehler **AMOUNT_MISMATCH** führt, weil die 6 Cent MwSt. der Zahlungsart bei der API-Übertragung fehlen.

--

When a payment-method surcharge is applied and blShowVATForPayCharge is enabled, creating the PayPal order fails with HTTP 422:

field:   /purchase_units/@reference_id=='OXID_REFERENCE'/amount/value
issue:   AMOUNT_MISMATCH
description: Should equal item_total + tax_total + shipping + handling + insurance + gratuity - shipping_discount - discount.

The breakdown total ends up higher than amount.value by exactly the VAT amount of the surcharge.

--

How to reproduce:

1. Make sure the PayPal Checkout module (v2.8.3 / v2.8.4) is active and configured with either live or sandbox credentials.
2. In the OXID admin, configure the payment method Paypal with a surcharge:
    Shop Settings → Payment Methods → PayPal (oscpaypal) → input "Price Surcharge/Reduction (€)" → set an absolute surcharge of e.g. 0.39
3. Enable "blShowVATForPayCharge":
    Master Settings → Core Settings → Settings → "VAT" → check "Display VAT contained in Payment Method Charges in Shopping Cart and Invoice".
4. In the storefront, add one or more articles to the basket (any standard 19% VAT product).
5. Proceed to checkout, select PayPal as the payment method (so the surcharge is applied to the basket).
6. On the order step, trigger the PayPal order creation. The paypal window will show up for a second and vanish again. 

Result: PayPal returns HTTP 422 AMOUNT_MISMATCH. The request log shows a "Rounding Adjustment" line item that is too large by the surcharge VAT amount, so: item_total + shipping − discount exceeds amount.value by exactly that VAT amount (e.g. 0.06 €).

Note: With blShowVATForPayCharge disabled the order is created successfully — which confirms the faulty payment_vat subtraction in PayPalAmountValidator.

--

Additional info:

Root cause

Two issues combine:

1. PayPalPurchaseUnitsFactory (src/Service/Factory/PayPalPurchaseUnitsFactory.php) builds amount.value from $basket->getPrice()->getBruttoPrice() (which includes the surcharge), but mapItems() / buildAmountArray() never add the surcharge as a line item or to the breakdown. 
(The older OrderRequestFactory added it via getPayPalCheckoutPayment(), but that path is no longer used — getPurchaseUnits() is now the single source.)

2. PayPalAmountValidator::calculateItemsTotal() then tries to compensate via a "Rounding Adjustment" item, but it subtracts the surcharge VAT from itemsTotal:

// src/Service/PayPalAmountValidator.php  (~lines 149-152)
$paymentVat = isset($breakdown['payment_vat']) ? (float)$breakdown['payment_vat'] : 0.0;
if ($paymentVat > 0) {
    $total -= $paymentVat;
}

2. payment_vat is injected earlier (validateAndAdjustOrder(), ~lines 33-41) via VatOptionsService::getPaymentVatAmount() when isPaymentVatVisible() is true. This makes the adjustment item too large by the surcharge VAT, so the resulting breakdown total no longer matches amount.value.

Worked example (from a real failing request, anonymized)

Surcharge: 0.33 € net → 0.39 € gross, VAT part 0.06 €.

Real basket: item 386.78 + shipping 6.95 + surcharge 0.39 = 394.12 (amount.value).

Validator computation:

  items before adjustment            386.78
  itemsTotal = 386.78 + 6.95 - 0.06  393.67   (shipping +6.95, payment_vat -0.06)
  breakdownTotal = amount_value      394.12
  difference                          -0.45
  -> "Rounding Adjustment" item        0.45
  resulting item_total = 386.78+0.45 387.23

PayPal recomputes: item_total 387.23 + shipping 6.95 = 394.18 vs amount.value 394.12 → mismatch 0.06 (exactly the surcharge VAT).

Sent request (anonymized):
{
  "amount": {
    "value": "394.12",
    "breakdown": {
      "item_total": {"value": "387.23"},
      "shipping":   {"value": "6.95"},
      "tax_total":  {"value": "0.00"},
      "discount":   {"value": "0.00"}
    } 
  },
  "items": [
    {"name": "<product>", "unit_amount": {"value": "386.78"}, "quantity": "1", "tax_rate": "19"},
    {"name": "Rounding Adjustment", "unit_amount": {"value": "0.45"}, "quantity": "1", "tax_rate": "0"}
  ]
}

Expected behavior

amount.value equals the sum of the breakdown components; the payment-method surcharge is represented correctly (either as its own line item or via handling), independent of the blShowVATForPayCharge setting.